### PR TITLE
fix:delete card move condition

### DIFF
--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { DndProvider, DropTargetMonitor, useDrag, useDrop } from "react-dnd";
+import { DndProvider, useDrag, useDrop } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 type CardData = {

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -188,7 +188,7 @@ const DraggableCard: React.FC<DraggableCardProps> = ({
         handlerId: monitor.getHandlerId(),
       };
     },
-    hover(item: unknown, monitor: DropTargetMonitor<unknown, unknown>) {
+    hover(item: unknown) {
       const typedItem = item as { index: number };
       if (!ref.current) {
         return;
@@ -197,19 +197,6 @@ const DraggableCard: React.FC<DraggableCardProps> = ({
       const hoverIndex = index;
 
       if (dragIndex === hoverIndex) {
-        return;
-      }
-
-      const hoverBoundingRect = ref.current?.getBoundingClientRect();
-      const hoverMiddleY =
-        (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
-      const clientOffset = monitor.getClientOffset();
-      const hoverClientY = clientOffset!.y - hoverBoundingRect.top;
-
-      if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
-        return;
-      }
-      if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
         return;
       }
 


### PR DESCRIPTION
## Issue
<!-- issueのリンク -->
#34 
## 処理概要
<!-- 実装内容や処理の流れの概要を記載して下さい -->
- カード移動時の条件削除
## 要件・仕様
<!-- チケットに記載されたもので構わないので、こちらにも記載してください -->
- カードを左から右へ移動できないので修正する
## 特記 / 特にレビューしてほしい箇所
<!-- 複雑な処理が含まれる場合は、設計・実装方針を記載してください
※ コードにコメントと言う形での記載も可 -->
<!-- 特にレビューしてほしい箇所があればここに書いてください　-->
- 厳密にはカードが移動できないわけではなく、下記条件下で移動ができない設定になっていた
    - カードを上に移動させる時、上のカードの下半分まではドラッグしても何も起こらない
    - カードを下に移動させる時、下のカードの上半分まではドラッグしても何も起こらない
    - カードが平行に位置するとき、左のカードは上、右のカードは下判定になる
- 正直この条件は消してもユーザビリティにあまり問題なさそうだったので抹消しました。
## 動作確認
<!-- 基本的には、動作確認はmustでお願いします-->
<!-- 動作確認が未実施の場合はその理由を書いてください。もしくは、今後動作確認実施予定がある場合はその旨を記載して下さい -->
- ローカルで動作確認済み
## パフォーマンス影響
<!-- 実装上、パフォーマンス影響がある場合は影響範囲と影響度を記載してください -->
- なし